### PR TITLE
Incorrect command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Commands:
 2. The CPO runs the tool to set it up to extract data for the consumer partner:
 
 ```bash
-ocpi  login http://example.org/url-to-version-endpoint --party-id XX-YYY --token token-for-partner-from-step-1
+ocpi  login http://example.org/url-to-version-endpoint --party XX-YYY --token token-for-partner-from-step-1
 ```
 
 where `XX-YYY` is replaced by a party ID for the party consuming the output of the tool. OCPI, at least in version 2.2.1, requires a party ID to be presented in every request so the tool needs one in order to contact the platform it is getting data from.


### PR DESCRIPTION
Wrong:
```
$ ocpi  login https://api.chargeit-mobility.com/ocpi/v2.1/versions --party-id DE-BDP --token ab
error: required option '--party <party>' not specified
```

Correct:
```
$ ocpi  login https://api.chargeit-mobility.com/ocpi/v2.1/versions --party DE-BDP --token ab
It's a versions endpoint; please pick one of the version URLs to log in to:
        2.1.1   https://api.chargeit-mobility.com/ocpi/v2.1/versions/2.1.1
```