### PR TITLE
Split location PrivacyDescriptor by OCPI version

### DIFF
--- a/src/privacy/cdr.ts
+++ b/src/privacy/cdr.ts
@@ -1,4 +1,4 @@
-import { locationDescriptor } from "./location";
+import { locationDescriptorV211 } from "./location";
 import {
   chargingPeriodDescriptor,
   cdrTokenDescriptor,
@@ -56,7 +56,7 @@ export const cdrDescriptorV211: PrivacyDescriptor = {
   ...baseCdrDescriptor,
   stop_date_time: "na",
   auth_id: "na",
-  location: locationDescriptor,
+  location: locationDescriptorV211,
   total_cost: "na",
 };
 

--- a/src/privacy/filter.ts
+++ b/src/privacy/filter.ts
@@ -1,6 +1,6 @@
 import { ModuleID, OcpiVersion } from "../ocpi-request";
 
-import { locationDescriptor } from "./location";
+import { locationDescriptorV211, locationDescriptorV221 } from "./location";
 import { sessionDescriptorV211, sessionDescriptorV221 } from "./session";
 import { cdrDescriptorV211, cdrDescriptorV221 } from "./cdr";
 import { tariffDescriptor } from "./tariff";
@@ -24,7 +24,7 @@ export const modulePrivacyDescriptors: Record<
   Record<OcpiVersion, PrivacyDescriptor>
 > = {
   cdrs: { "2.1.1": cdrDescriptorV211, "2.2.1": cdrDescriptorV221 },
-  locations: { "2.1.1": locationDescriptor, "2.2.1": locationDescriptor },
+  locations: { "2.1.1": locationDescriptorV211, "2.2.1": locationDescriptorV221 },
   sessions: { "2.1.1": sessionDescriptorV211, "2.2.1": sessionDescriptorV221 },
   tariffs: { "2.1.1": tariffDescriptor, "2.2.1": tariffDescriptor },
   tokens: { "2.1.1": tokenDescriptor, "2.2.1": tokenDescriptor },

--- a/src/privacy/location.ts
+++ b/src/privacy/location.ts
@@ -24,22 +24,31 @@ const displayTextDescriptor: PrivacyDescriptor = {
   text: "na",
 };
 
-const connectorDescriptor: PrivacyDescriptor = {
+const baseConnectorDescriptor: PrivacyDescriptor = {
   id: "pass",
   standard: "pass",
   format: "pass",
   power_type: "pass",
-  voltage: "pass",
-  amperage: "pass",
-  max_voltage: "pass",
-  max_amperage: "pass",
-  max_electric_power: "pass",
-  tariff_ids: ["pass"],
   terms_and_conditions: "pass",
   last_updated: "na",
 };
 
-const evseDescriptor: PrivacyDescriptor = {
+const connectorDescriptorV211: PrivacyDescriptor = {
+  ...baseConnectorDescriptor,
+  voltage: "pass",
+  amperage: "pass",
+  tariff_id: "pass",
+};
+
+const connectorDescriptorV221: PrivacyDescriptor = {
+  ...baseConnectorDescriptor,
+  max_voltage: "pass",
+  max_amperage: "pass",
+  max_electric_power: "pass",
+  tariff_ids: ["pass"],
+};
+
+const evseDescriptorV211: PrivacyDescriptor = {
   uid: "pass",
   evse_id: "na",
   status: "na",
@@ -58,7 +67,7 @@ const evseDescriptor: PrivacyDescriptor = {
     },
   ],
   capabilities: ["pass"],
-  connectors: [connectorDescriptor],
+  connectors: [connectorDescriptorV211],
   floor_level: "pass",
   coordinates: geoLocationDescriptor,
   physical_reference: "na",
@@ -68,7 +77,12 @@ const evseDescriptor: PrivacyDescriptor = {
   last_updated: "na",
 };
 
-export const locationDescriptor: PrivacyDescriptor = {
+const evseDescriptorV221: PrivacyDescriptor = {
+  ...evseDescriptorV211,
+  connectors: [connectorDescriptorV221],
+};
+
+export const locationDescriptorV211: PrivacyDescriptor = {
   country_code: "pass",
   party_id: "pass",
   id: "pass",
@@ -92,7 +106,7 @@ export const locationDescriptor: PrivacyDescriptor = {
   coordinates: geoLocationDescriptor,
   related_locations: geoLocationDescriptor,
   parking_type: "pass",
-  evses: [evseDescriptor],
+  evses: [evseDescriptorV211],
   directions: [displayTextDescriptor],
   operator: {
     name: "pass",
@@ -137,4 +151,9 @@ export const locationDescriptor: PrivacyDescriptor = {
   images: [imageDescriptor],
   energy_mix: [energyMixDescriptor],
   last_updated: "na",
+};
+
+export const locationDescriptorV221: PrivacyDescriptor = {
+  ...locationDescriptorV211,
+  evses: [evseDescriptorV221],
 };


### PR DESCRIPTION
When performing a get locations operation against an OCPI 2.1.1 endpoint, the ocpi-tool would fail. OCPI 2.1.1 expects `location.evses[].connectors[].tariff_id`, OCPI 2.2.1 expects `location.evses[].connectors[].tariff_ids[]`.

I tried to split the versioned `PrivacyDescriptor` similar to what was done in `session.ts`.