### PR TITLE
Added sourceMap to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
+    "sourceMap": true,
     "strict": true,
     "target": "es2019"
   },


### PR DESCRIPTION
Enabling `sourceMap` made [debugging in VS Code](https://code.visualstudio.com/docs/typescript/typescript-debugging) out-of-the-box easier.

I'm unsure whether project maintainers would want [`sourceMap`](https://www.typescriptlang.org/tsconfig#sourceMap) set in `tsconfig.json` or passed at compile time with the `--sourcemap` option. Feel free to accept or reject this PR accordingly.