### PR TITLE
Modifies jsonEncodingStream to construct an array

### DIFF
--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -68,10 +68,20 @@ export const get = async (moduleName: string, privacyPass?: string) => {
 
   const jsonEncodingStream = new Transform({
     writableObjectMode: true,
-    transform(chunk, encoding, callback) {
-      this.push(JSON.stringify(chunk));
+    construct(callback) {
+      this.push("[");
       callback();
     },
+    transform(chunk, encoding, callback) {
+      this.emit("append_item");
+      this.push(JSON.stringify(chunk));
+      this.once("append_item", () => { this.push(",") });
+      callback();
+    },
+    flush(callback) {
+      this.push("]");
+      callback();
+    }
   });
 
   try {


### PR DESCRIPTION
Currently, when using a command like:

```bash
node ./dist/index.js get locations
```

Multiple items are output as:

```javascript
{ "foo": "bar1"} { "foo": "bar2"}
```

This is not a syntactically valid array. When piped to jq, as suggested by the README, something as simple as the following throws an error:

```bash
node ./dist/index.js get locations | jq .
```

This is due to the array syntax error. The output should be:

```javascript
[ { "foo": "bar1"}, {"foo": "bar2"} ]
```

This commit modifies the `jsonEncodingStream` to construct a syntactically valid array. 

I haven't done super thorough testing yet. I think this implementation might be a bit brittle. So far, it's working for me when tested against small collections.